### PR TITLE
chore: add `sandbox/reade_sample.rs` and check buildability of README's sample code

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,4 +55,6 @@ jobs:
             || (grep 'Neither miniflare D1 emulator nor .sqlx directory is found !' tmp.log && echo '---> expected behavior' || exit 1)
           mv ./tmp ./.sqlx
           cargo build
-          cargo build --features DEBUG  # check `readme_sample`
+          echo '---> build suceeded with .sqlx directory as expected'
+          cargo build --features DEBUG  # checking `readme_sample`
+          echo '---> `readme_sample` is sucessfully built'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Check sandbox
         working-directory: ./sandbox
-        run: | # sandbox has `.cargo/config.toml` that specifies `target = "wasm32-unknown-unknown"`
+        run: |  # sandbox has `.cargo/config.toml` that specifies `target = "wasm32-unknown-unknown"`
           mv ./wrangler.toml.sample ./wrangler.toml
           mv ./.sqlx ./tmp
           cargo build 2>&1 | tee tmp.log \
@@ -55,3 +55,4 @@ jobs:
             || (grep 'Neither miniflare D1 emulator nor .sqlx directory is found !' tmp.log && echo '---> expected behavior' || exit 1)
           mv ./tmp ./.sqlx
           cargo build
+          cargo build --features DEBUG  # check `readme_sample`

--- a/sandbox/.sqlx/query-762560510434fd845505ba5356aa6e157c042563302a471021c7b7af5de647d4.json
+++ b/sandbox/.sqlx/query-762560510434fd845505ba5356aa6e157c042563302a471021c7b7af5de647d4.json
@@ -1,0 +1,1 @@
+{"columns":[{"ordinal":0,"name":"id","type_info":"INTEGER"}],"parameters":{"Right":2},"nullable":[false]}

--- a/sandbox/Cargo.lock
+++ b/sandbox/Cargo.lock
@@ -24,21 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,12 +124,9 @@ version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
- "android-tzdata",
- "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link",
 ]
 
 [[package]]
@@ -165,12 +147,6 @@ dependencies = [
  "cfg-if",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -496,29 +472,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +764,7 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "ohkami",
+ "serde",
  "sqlx-d1",
  "thiserror 2.0.11",
  "worker",
@@ -1082,7 +1036,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a007b6936676aa9ab40207cde35daab0a04b823be8ae004368c0793b96a61e0"
 dependencies = [
  "bytes",
- "chrono",
  "crossbeam-queue",
  "either",
  "event-listener",
@@ -1098,12 +1051,10 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "serde",
- "serde_json",
  "smallvec",
  "thiserror 2.0.11",
  "tracing",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -1400,12 +1351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "uuid"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,21 +1464,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"

--- a/sandbox/Cargo.toml
+++ b/sandbox/Cargo.toml
@@ -14,6 +14,7 @@ sqlx-d1 = { path = "../sqlx-d1", features = ["macros"] }
 console_error_panic_hook = "0.1"
 thiserror = "2.0"
 worker = { version = "0.5" }
+serde = { optional = true, version = "1.0", features = ["derive"] }
 
 [dependencies.ohkami]
 git = "https://github.com/ohkami-rs/ohkami"
@@ -21,4 +22,4 @@ branch = "v0.24"
 features = ["rt_worker"]
 
 [features]
-DEBUG = ["sqlx-d1/DEBUG"]
+DEBUG = ["sqlx-d1/DEBUG", "dep:serde"]

--- a/sandbox/src/lib.rs
+++ b/sandbox/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "DEBUG")]
+mod readme_sample;
+
 use ohkami::prelude::*;
 use ohkami::typed::status;
 use sqlx_d1::D1Connection;

--- a/sandbox/src/lib.rs
+++ b/sandbox/src/lib.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "DEBUG")]
-mod readme_sample;
+pub mod readme_sample;
 
 use ohkami::prelude::*;
 use ohkami::typed::status;

--- a/sandbox/src/readme_sample.rs
+++ b/sandbox/src/readme_sample.rs
@@ -1,4 +1,4 @@
-async fn _main(
+pub async fn main(
     mut req: worker::Request,
     env: worker::Env,
     _ctx: worker::Context,

--- a/sandbox/src/readme_sample.rs
+++ b/sandbox/src/readme_sample.rs
@@ -1,0 +1,31 @@
+async fn _main(
+    mut req: worker::Request,
+    env: worker::Env,
+    _ctx: worker::Context,
+) -> worker::Result<worker::Response> {
+    let d1 = env.d1("DB")?;
+    let conn = sqlx_d1::D1Connection::new(d1);
+
+    #[derive(serde::Deserialize)]
+    struct CreateUser {
+        name: String,
+        age: Option<u8>,
+    }
+
+    let req = req.json::<CreateUser>().await?;
+
+    let id = sqlx_d1::query!(
+        "
+        INSERT INTO users (name, age) VALUES (?, ?)
+        RETURNING id
+        ",
+            req.name,
+            req.age
+        )
+        .fetch_one(&conn)
+        .await
+        .map_err(|e| worker::Error::RustError(e.to_string()))?
+        .id;
+
+    worker::Response::ok(format!("Your id is {id}!"))
+}

--- a/sqlx-d1/src/macros.rs
+++ b/sqlx-d1/src/macros.rs
@@ -14,7 +14,7 @@ macro_rules! query (
     ($query:expr) => ({
         $crate::macros::sqlx_d1_macros::expand_query!(source = $query)
     });
-    ($query:expr, $($args:expr),* $(,)?) => ({
+    ($query:expr, $($args:tt)*) => ({
         $crate::macros::sqlx_d1_macros::expand_query!(source = $query, args = [$($args)*])
     })
 );
@@ -28,7 +28,7 @@ macro_rules! query_unchecked (
     ($query:expr) => ({
         $crate::macros::sqlx_d1_macros::expand_query!(source = $query, checked = false)
     });
-    ($query:expr, $($args:expr),* $(,)?) => ({
+    ($query:expr, $($args:tt)*) => ({
         $crate::macros::sqlx_d1_macros::expand_query!(source = $query, args = [$($args)*], checked = false)
     })
 );


### PR DESCRIPTION
When `--target wasm32-unknown-unknown`, README's sample codes seem not tested by `cargo test --doc`.

This PR introduces `readme_sample` module in sandbox to enable to check its buildability in CI and copy the code to README.