### PR TITLE
feat: `D1ConnectOptions::connect`

### DIFF
--- a/sandbox/Cargo.lock
+++ b/sandbox/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "shlex",
 ]
@@ -647,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -863,9 +863,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]

--- a/sandbox/src/lib.rs
+++ b/sandbox/src/lib.rs
@@ -60,8 +60,15 @@ async fn my_worker(Bindings { DB }: Bindings) -> Ohkami {
     #[cfg(debug_assertions)]
     console_error_panic_hook::set_once();
 
+    let d1_connection = sqlx_d1::D1ConnectOptions::new(DB)
+        .foreign_keys(true)
+        .connect()
+        .await
+        .expect("Failed to connect to D1");
+
     Ohkami::new((
-        Context::new(D1Connection::new(DB)),
+        Context::new(d1_connection),
+        
         "/"
             .GET(async |
                 Context(c): Context<'_, D1Connection>,


### PR DESCRIPTION
closes #23 

tested by: `sandbox`

---

The original issue suggests `D1Connection::connect_with(options)`, but applying options executing its pragmas in background, and it requires to be async and returning Result. So, the signature is completely different from `D1Connection::new`, which just wraps existing `worker::D1Database`, and `connect_with` may be not intuitive.

This PR exposes `<D1ConnectOptions>::connect(self)` method, in addition to the `connect(&self)` of `sqlx_core::connection::ConnectOptions` trait, allowing to easily handle pragmas by `D1ConnectOptions` (without importing anything other).