### PR TITLE
Fix: Use runtime CARGO_MANIFEST_DIR in D1ConnectOptions::from_str

### DIFF
--- a/sqlx-d1-core/src/connection.rs
+++ b/sqlx-d1-core/src/connection.rs
@@ -563,10 +563,11 @@ const _: () = {
                         .join("miniflare-D1DatabaseObject")
                 }
 
-                const PACKAGE_ROOT: &str = env!("CARGO_MANIFEST_DIR");
+                // Should usually be set by cargo at compile time. Falls back to an empty string if unset.
+                let package_root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
 
                 let (candidate_1, candidate_2) = (
-                    maybe_miniflare_d1_dir_of(PACKAGE_ROOT),
+                    maybe_miniflare_d1_dir_of(&package_root),
                     maybe_miniflare_d1_dir_of("."),
                 );
 


### PR DESCRIPTION
This fix allows sqlx-d1 to find the `.wrangler` directory in Cargo workspaces where the crate using wrangler is not at the workspace root.

`D1ConnectOptions::from_str` searches for the miniflare D1 emulator's SQLite file to enable compile-time query verification. One of its search candidates used `env!("CARGO_MANIFEST_DIR")`, which is evaluated at compile time in sqlx-d1-core itself. That means it always resolves to the sqlx-d1-core crate's path in the cargo registry and never find `.wrangler/`.

The other candidate, `"."`, uses the CWD at proc-macro expansion time.  Cargo sets this to the workspace root when running rustc, so it works in single-crate projects, but fails in Cargo workspaces where `.wrangler/` lives inside a member crate rather than the workspace root.

The result is a `WorkerCrashed` error at compile time:

```
error: sqlx reported `WorkerCrashed`: maybe bug or invalid use of `sqlx_d1`. Be sure to use `sqlx_d1` where the target is set to `wasm32-unknown-unknown` !
      For this, typcally, place `.cargo/config.toml` of following content at the root of your project or workspace :

      [build]
      target = "wasm32-unknown-unknown"

      If you think this of a bug, please let me know the situation in GitHub Issues (https://github.com/ohkami-rs/sqlx-d1/issues) !
--> coach-server/src/db/roles.rs:74:9
   |
74 |         sqlx_d1::query_as!(UserRole, "SELECT * FROM roles WHERE user_id = ?", user_id)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `sqlx_d1::query_as` (in Nightly builds, run with -Z macro-backtrace for more info)
```

The fix is to replace `env!("CARGO_MANIFEST_DIR")` with `std::env::var("CARGO_MANIFEST_DIR")`. The runtime env var is set by cargo to the *user's* crate directory at proc-macro expansion time, which is where `.wrangler/` actually lives.  The `"."` fallback is kept for cases where the env var is unset.